### PR TITLE
qt 5.x.x: add fix for virtual can backend usage in multithreaded environment

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -139,6 +139,11 @@ patches:
       "patch_file": "patches/5.15.12-fix-macos-cpp-lib-memory-resource.patch"
       "patch_source": "https://codereview.qt-project.org/c/qt/qtbase/+/482392"
       "patch_type": "portability"
+    - "base_path": "qt5/qtserialbus"
+      "patch_description": "Fix virtual can backend usage in multithreaded environment"
+      "patch_file": "patches/qtvirtualcanbackend.patch"
+      "patch_source": "https://codereview.qt-project.org/c/qt/qtserialbus/+/565329"
+      "patch_type": "backport"
   "5.15.13":
     - "base_path": "qt5/qtbase"
       "patch_file": "patches/aa2a39dea5.diff"
@@ -162,6 +167,11 @@ patches:
       "patch_file": "patches/5.15.12-fix-macos-cpp-lib-memory-resource.patch"
       "patch_source": "https://codereview.qt-project.org/c/qt/qtbase/+/482392"
       "patch_type": "portability"
+    - "base_path": "qt5/qtserialbus"
+      "patch_description": "Fix virtual can backend usage in multithreaded environment"
+      "patch_file": "patches/qtvirtualcanbackend.patch"
+      "patch_source": "https://codereview.qt-project.org/c/qt/qtserialbus/+/565329"
+      "patch_type": "backport"
   "5.15.12":
     - "base_path": "qt5/qtbase"
       "patch_file": "patches/aa2a39dea5.diff"

--- a/recipes/qt/5.x.x/patches/qtvirtualcanbackend.patch
+++ b/recipes/qt/5.x.x/patches/qtvirtualcanbackend.patch
@@ -1,0 +1,48 @@
+diff --git a/src/plugins/canbus/virtualcan/virtualcanbackend.cpp b/src/plugins/canbus/virtualcan/virtualcanbackend.cpp
+index ce1ca3e9..4e366dc1 100644
+--- a/src/plugins/canbus/virtualcan/virtualcanbackend.cpp
++++ b/src/plugins/canbus/virtualcan/virtualcanbackend.cpp
+@@ -38,7 +38,9 @@
+ 
+ #include <QtCore/qdatetime.h>
+ #include <QtCore/qloggingcategory.h>
++#include <QtCore/qmutex.h>
+ #include <QtCore/qregularexpression.h>
++#include <QtCore/qthread.h>
+ 
+ #include <QtNetwork/qtcpserver.h>
+ #include <QtNetwork/qtcpsocket.h>
+@@ -78,6 +80,13 @@ void VirtualCanServer::start(quint16 port)
+         return;
+     }
+ 
++    if (QThread::currentThread() != this->thread()) {
++        // This can happen if this methode is invoked a second time by a different thread
++        // than when it was invoked the first time, and the first time the QTcpServer
++        // couldn't listen because the TCP port was taken by a different process on the system
++        return;
++    }
++
+     // Otherwise try to start a new server. If there is already
+     // another server listen on the specified port, give up.
+     m_server = new QTcpServer(this);
+@@ -164,6 +173,7 @@ void VirtualCanServer::readyRead()
+ }
+ 
+ Q_GLOBAL_STATIC(VirtualCanServer, g_server)
++static QBasicMutex g_serverMutex;
+ 
+ VirtualCanBackend::VirtualCanBackend(const QString &interface, QObject *parent)
+     : QCanBusDevice(parent)
+@@ -205,8 +215,10 @@ bool VirtualCanBackend::open()
+     const QHostAddress address = host.isEmpty() ? QHostAddress::LocalHost : QHostAddress(host);
+     const quint16 port = static_cast<quint16>(m_url.port(ServerDefaultTcpPort));
+ 
+-    if (address.isLoopback())
++    if (address.isLoopback()) {
++        const QMutexLocker locker(&g_serverMutex);
+         g_server->start(port);
++    }
+ 
+     m_clientSocket = new QTcpSocket(this);
+     m_clientSocket->connectToHost(address, port, QIODevice::ReadWrite);


### PR DESCRIPTION
Specify library name and version:  **Qt/5.15.13** and **Qt/5.15.14**
